### PR TITLE
Update LocalRxBase.cpp

### DIFF
--- a/src/svxlink/trx/LocalRxBase.cpp
+++ b/src/svxlink/trx/LocalRxBase.cpp
@@ -521,6 +521,16 @@ bool LocalRxBase::initialize(void)
 
     // Filter out the voice band, removing high- and subaudible frequencies,
     // for example CTCSS.
+    // RX VoiceBandFilter	
+string filterdesc;
+if (cfg().getValue(name(),"RX_AUDIO_FILTER",filterdesc))
+{
+    AudioFilter *voiceband_filter = new AudioFilter(filterdesc);
+    prev_src->registerSink(voiceband_filter, true);
+    prev_src = voiceband_filter;
+}
+else
+{
 #if (INTERNAL_SAMPLE_RATE == 16000)
   AudioFilter *voiceband_filter = new AudioFilter("BpCh12/-0.1/300-5000");
 #else
@@ -615,6 +625,8 @@ bool LocalRxBase::initialize(void)
     prev_src->registerSink(limit, true);
     prev_src = limit;
   }
+  else
+  {
 
     // Clip audio to limit its amplitude
   AudioClipper *clipper = new AudioClipper;


### PR DESCRIPTION
implement a filter section in svxlink.conf - [RX] section, in order to adjust the audio level for an improved and linear audio.
section: RX_AUDIO_FILTER
Value: [filter+order]/dB/[cut-off-frequency]
example:  LpCh6/-0.1/3000
Bandpass =Bp, Lowpass=Lp...
Lowpass Chebyshev filter 6th order and -3dB cut-off frequency at 3.0kHz - in our tests the example was the best solution.